### PR TITLE
Expose interfaces

### DIFF
--- a/TorBoxNET/Apis/Queued.cs
+++ b/TorBoxNET/Apis/Queued.cs
@@ -5,15 +5,8 @@ using System.Xml.Linq;
 
 namespace TorBoxNET;
 
-public class QueuedApi
+public interface IQueuedApi
 {
-    private readonly Requests _requests;
-
-    internal QueuedApi(HttpClient httpClient, Store store)
-    {
-        _requests = new Requests(httpClient, store);
-    }
-
     /// <summary>
     /// Gets the list of user's queued downloads. If an ID is supplied, returns a list containing one download.
     /// </summary>
@@ -24,6 +17,25 @@ public class QueuedApi
     /// <param name="limit">Limits the number of returned items. Defaults to 1000.</param>
     /// <param name="cancellationToken">A token to cancel the task if necessary.</param>
     /// <returns>A list of TorrentInfoResult, an empty list if nothing is found, null if request failed.</returns>
+    Task<List<QueuedDownload>?> GetQueuedAsync(
+        bool skipCache = false,
+        string type = "torrent",
+        int? id = null,
+        int offset = 0,
+        int limit = 1000,
+        CancellationToken cancellationToken = default);
+}
+
+public class QueuedApi : IQueuedApi
+{
+    private readonly Requests _requests;
+
+    internal QueuedApi(HttpClient httpClient, Store store)
+    {
+        _requests = new Requests(httpClient, store);
+    }
+
+    /// <inheritdoc />
     public async Task<List<QueuedDownload>?> GetQueuedAsync(
         bool skipCache = false,
         string type = "torrent",

--- a/TorBoxNET/Apis/Torrents.cs
+++ b/TorBoxNET/Apis/Torrents.cs
@@ -8,19 +8,8 @@ namespace TorBoxNET;
 /// Provides methods for interacting with the torrent-related API endpoints, including adding, 
 /// retrieving, and controlling torrents, as well as requesting download links.
 /// </summary>
-public class TorrentsApi
+public interface ITorrentsApi
 {
-    private readonly Requests _requests;
-    private readonly Store _store;
-    private readonly QueuedApi _queued;
-
-    internal TorrentsApi(HttpClient httpClient, Store store, QueuedApi queued)
-    {
-        _requests = new Requests(httpClient, store);
-        _store = store;
-        _queued = queued;
-    }
-
     /// <summary>
     /// Retrieves the total number of user torrents.
     /// </summary>
@@ -33,17 +22,7 @@ public class TorrentsApi
     /// <returns>
     /// The total number of torrents, or -1 if the request fails.
     /// </returns>
-    public async Task<Int64> GetTotal(bool skipCache = false, CancellationToken cancellationToken = default)
-    {
-        var res = await GetCurrentAsync(skipCache, cancellationToken);
-
-        if (res == null)
-        {
-            return -1;
-        }
-
-        return res.Count;
-    }
+    Task<Int64> GetTotal(bool skipCache = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Fetches the list of active torrents for the user.
@@ -57,6 +36,157 @@ public class TorrentsApi
     /// <returns>
     /// A list of torrents if the request succeeds, otherwise null.
     /// </returns>
+    Task<List<TorrentInfoResult>?> GetCurrentAsync(bool skipCache = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the list of user's queued torrents.
+    /// </summary>
+    /// <param name="skipCache">Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.</param>
+    /// <param name="cancellationToken">A token to cancel the task if necessary.</param>
+    /// <returns>A list of TorrentInfoResult, an empty list if nothing is found, null if request failed.</returns>
+    Task<List<TorrentInfoResult>?> GetQueuedAsync(
+        bool skipCache = false,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves detailed information about a specific torrent by its ID.
+    /// Checks both active and queued torrents.
+    /// </summary>
+    /// <param name="id">The unique identifier of the torrent.</param>
+    /// <param name="skipCache">
+    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// Information about the torrent if found, otherwise null.
+    /// </returns>
+    Task<TorrentInfoResult?> GetIdInfoAsync(int id, bool skipCache = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves detailed information about a specific torrent by its hash.
+    /// Checks both active and queued torrents.
+    /// </summary>
+    /// <param name="hash">The unique hash identifier of the torrent.</param>
+    /// <param name="skipCache">
+    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// Information about the torrent if found, otherwise null.
+    /// </returns>
+    Task<TorrentInfoResult?> GetHashInfoAsync(string hash, bool skipCache = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a torrent file to the torrent client.
+    /// </summary>
+    /// <param name="file">The torrent file as a byte array.</param>
+    /// <param name="seeding">
+    /// Seeding preference: 1 for auto, 2 for seed, and 3 for no seed.
+    /// </param>
+    /// <param name="allowZip">Whether to allow zipped torrents.</param>
+    /// <param name="name">Optional name for the torrent.</param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// The response containing information about the added torrent.
+    /// </returns>
+    Task<Response<TorrentAddResult>> AddFileAsync(Byte[] file, int seeding = 1, bool allowZip = false, string? name = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a magnet link to the torrent client.
+    /// </summary>
+    /// <param name="magnet">The magnet link to be added.</param>
+    /// <param name="seeding">
+    /// Seeding preference: 1 for auto, 2 for seed, and 3 for no seed.
+    /// </param>
+    /// <param name="allowZip">Whether to allow zipped torrents.</param>
+    /// <param name="name">Optional name for the torrent.</param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// The response containing information about the added torrent.
+    /// </returns>
+    Task<Response<TorrentAddResult>> AddMagnetAsync(string magnet, int seeding = 1, bool allowZip = false, string? name = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Modifies the state of a torrent (e.g., pause, resume, reannounce, delete).
+    /// </summary>
+    /// <param name="hash">The unique hash of the torrent.</param>
+    /// <param name="action">
+    /// The action to perform: pause, resume, reannounce, or delete.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// The response after performing the action.
+    /// </returns>
+    Task<Response> ControlAsync(string hash, string action, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the availability of a torrent (whether it's cached and ready to download).
+    /// </summary>
+    /// <param name="hash">The unique hash identifier of the torrent.</param>
+    /// <param name="listFiles">Whether to include file list in the response.</param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// A response containing availability information for the torrent.
+    /// </returns>
+    Task<Response<List<AvailableTorrent?>>> GetAvailabilityAsync(string hash, bool listFiles = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Requests a download link for a specific torrent or file.
+    /// </summary>
+    /// <param name="torrent_id">The ID of the torrent to download.</param>
+    /// <param name="file_id">The ID of the file within the torrent (optional).</param>
+    /// <param name="zip">
+    /// Whether to download the entire torrent as a ZIP. If true, file_id is ignored.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// A response containing the download link.
+    /// </returns>
+    Task<Response<string>> RequestDownloadAsync(int torrent_id, int? file_id, bool zip = false, CancellationToken cancellationToken = default);
+}
+
+/// <inheritdoc />
+public class TorrentsApi : ITorrentsApi
+{
+    private readonly Requests _requests;
+    private readonly Store _store;
+    private readonly IQueuedApi _queued;
+
+    internal TorrentsApi(HttpClient httpClient, Store store, IQueuedApi queued)
+    {
+        _requests = new Requests(httpClient, store);
+        _store = store;
+        _queued = queued;
+    }
+
+    /// <inheritdoc />
+    public async Task<Int64> GetTotal(bool skipCache = false, CancellationToken cancellationToken = default)
+    {
+        var res = await GetCurrentAsync(skipCache, cancellationToken);
+
+        if (res == null)
+        {
+            return -1;
+        }
+
+        return res.Count;
+    }
+
+    /// <inheritdoc />
     public async Task<List<TorrentInfoResult>?> GetCurrentAsync(bool skipCache = false, CancellationToken cancellationToken = default)
     {
         var list = await _requests.GetRequestAsync($"torrents/mylist?bypass_cache={skipCache}", true, cancellationToken);
@@ -69,12 +199,7 @@ public class TorrentsApi
         return JsonConvert.DeserializeObject<Response<List<TorrentInfoResult>>>(list)?.Data;
     }
 
-    /// <summary>
-    /// Gets the list of user's queued torrents.
-    /// </summary>
-    /// <param name="skipCache">Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.</param>
-    /// <param name="cancellationToken">A token to cancel the task if necessary.</param>
-    /// <returns>A list of TorrentInfoResult, an empty list if nothing is found, null if request failed.</returns>
+    /// <inheritdoc />
     public async Task<List<TorrentInfoResult>?> GetQueuedAsync(
         bool skipCache = false,
         CancellationToken cancellationToken = default)
@@ -115,20 +240,7 @@ public class TorrentsApi
     }
 
 
-    /// <summary>
-    /// Retrieves detailed information about a specific torrent by its ID.
-    /// Checks both active and queued torrents.
-    /// </summary>
-    /// <param name="id">The unique identifier of the torrent.</param>
-    /// <param name="skipCache">
-    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// Information about the torrent if found, otherwise null.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<TorrentInfoResult?> GetIdInfoAsync(int id, bool skipCache = false, CancellationToken cancellationToken = default)
     {
         var currentTorrent = await _requests.GetRequestAsync($"torrents/mylist?bypass_cache={skipCache}", true, cancellationToken);
@@ -152,20 +264,7 @@ public class TorrentsApi
         return null;
     }
 
-    /// <summary>
-    /// Retrieves detailed information about a specific torrent by its hash.
-    /// Checks both active and queued torrents.
-    /// </summary>
-    /// <param name="hash">The unique hash identifier of the torrent.</param>
-    /// <param name="skipCache">
-    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// Information about the torrent if found, otherwise null.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<TorrentInfoResult?> GetHashInfoAsync(string hash, bool skipCache = false, CancellationToken cancellationToken = default)
     {
         var currentTorrents = await GetCurrentAsync(skipCache, cancellationToken);
@@ -197,21 +296,7 @@ public class TorrentsApi
         return null;
     }
 
-    /// <summary>
-    /// Adds a torrent file to the torrent client.
-    /// </summary>
-    /// <param name="file">The torrent file as a byte array.</param>
-    /// <param name="seeding">
-    /// Seeding preference: 1 for auto, 2 for seed, and 3 for no seed.
-    /// </param>
-    /// <param name="allowZip">Whether to allow zipped torrents.</param>
-    /// <param name="name">Optional name for the torrent.</param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// The response containing information about the added torrent.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response<TorrentAddResult>> AddFileAsync(Byte[] file, int seeding = 1, bool allowZip = false, string? name = null, CancellationToken cancellationToken = default)
     {
         using (var content = new MultipartFormDataContent())
@@ -237,21 +322,7 @@ public class TorrentsApi
         }
     }
 
-    /// <summary>
-    /// Adds a magnet link to the torrent client.
-    /// </summary>
-    /// <param name="magnet">The magnet link to be added.</param>
-    /// <param name="seeding">
-    /// Seeding preference: 1 for auto, 2 for seed, and 3 for no seed.
-    /// </param>
-    /// <param name="allowZip">Whether to allow zipped torrents.</param>
-    /// <param name="name">Optional name for the torrent.</param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// The response containing information about the added torrent.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response<TorrentAddResult>> AddMagnetAsync(string magnet, int seeding = 1, bool allowZip = false, string? name = null, CancellationToken cancellationToken = default)
     {
         var data = new List<KeyValuePair<string, string?>>
@@ -265,19 +336,7 @@ public class TorrentsApi
         return await _requests.PostRequestAsync<Response<TorrentAddResult>>("torrents/createtorrent", data, true, cancellationToken);
     }
 
-    /// <summary>
-    /// Modifies the state of a torrent (e.g., pause, resume, reannounce, delete).
-    /// </summary>
-    /// <param name="hash">The unique hash of the torrent.</param>
-    /// <param name="action">
-    /// The action to perform: pause, resume, reannounce, or delete.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// The response after performing the action.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response> ControlAsync(string hash, string action, CancellationToken cancellationToken = default)
     {
         var info = await GetHashInfoAsync(hash, skipCache: true, cancellationToken);
@@ -291,36 +350,13 @@ public class TorrentsApi
         return await _requests.PostRequestRawAsync<Response>(endpoint, jsonContent, true, cancellationToken);
     }
 
-    /// <summary>
-    /// Retrieves the availability of a torrent (whether it's cached and ready to download).
-    /// </summary>
-    /// <param name="hash">The unique hash identifier of the torrent.</param>
-    /// <param name="listFiles">Whether to include file list in the response.</param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// A response containing availability information for the torrent.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response<List<AvailableTorrent?>>> GetAvailabilityAsync(string hash, bool listFiles = false, CancellationToken cancellationToken = default)
     {
         return await _requests.GetRequestAsync<Response<List<AvailableTorrent?>>>($"torrents/checkcached?hash={hash}&format=list&list_files={listFiles}", true, cancellationToken);
     }
 
-    /// <summary>
-    /// Requests a download link for a specific torrent or file.
-    /// </summary>
-    /// <param name="torrent_id">The ID of the torrent to download.</param>
-    /// <param name="file_id">The ID of the file within the torrent (optional).</param>
-    /// <param name="zip">
-    /// Whether to download the entire torrent as a ZIP. If true, file_id is ignored.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// A response containing the download link.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response<string>> RequestDownloadAsync(int torrent_id, int? file_id, bool zip = false, CancellationToken cancellationToken = default)
     {
         var parameters = HttpUtility.ParseQueryString(string.Empty);

--- a/TorBoxNET/Apis/Usenet.cs
+++ b/TorBoxNET/Apis/Usenet.cs
@@ -4,18 +4,21 @@ using Newtonsoft.Json;
 
 namespace TorBoxNET;
 
-public class UsenetApi
+public interface IUsenetApi
 {
-    private readonly Requests _requests;
-    private readonly Store _store;
-    private readonly QueuedApi _queued;
-
-    internal UsenetApi(HttpClient httpClient, Store store, QueuedApi queued)
-    {
-        _requests = new Requests(httpClient, store);
-        _store = store;
-        _queued = queued;
-    }
+    /// <summary>
+    /// Fetches the list of active usenet downloads for the user.
+    /// </summary>
+    /// <param name="skipCache">
+    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// A list of usenet downloads if the request succeeds, otherwise null.
+    /// </returns>
+    Task<List<UsenetInfoResult>?> GetCurrentAsync(bool skipCache = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Fetches the list of active usenet downloads for the user.
@@ -29,6 +32,145 @@ public class UsenetApi
     /// <returns>
     /// A list of usenet downloads if the request succeeds, otherwise null.
     /// </returns>
+    Task<List<UsenetInfoResult>?> GetQueuedAsync(bool skipCache = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves detailed information about a specific usenet download by its hash.
+    /// </summary>
+    /// <param name="hash">The unique hash identifier of the torrent.</param>
+    /// <param name="skipCache">
+    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// Information about the download if found, otherwise null.
+    /// </returns>
+    Task<UsenetInfoResult?> GetHashInfoAsync(string hash, bool skipCache = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves detailed information about a usenet download by its id.
+    /// </summary>
+    /// <param name="id">The unique hash identifier of the usenet download.</param>
+    /// <param name="skipCache">
+    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// Information about the download if found, otherwise null.
+    /// </returns>
+    Task<UsenetInfoResult?> GetIdInfoAsync(int id, bool skipCache = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a nzb file to the remote client.
+    /// </summary>
+    /// <param name="file">The nzb file as a byte array.</param>
+    /// <param name="post_processing">
+    /// Proccessing preference: 
+    /// -1 for default, being repair, unpack, and delete,
+    /// 0 for no post proccessing actions,
+    /// 1 for repair files,
+    /// 2 for repair and unpack files,
+    /// 3 for repair, unpack, and delete source files.
+    /// </param>
+    /// <param name="name">Optional name for the usenet download.</param>
+    /// <param name="password">Optional password for the client to extract the files as.</param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// The response containing information about the added download.
+    /// </returns>
+    Task<Response<UsenetAddResult>> AddFileAsync(Byte[] file, int post_processing = -1, string? name = null, string? password = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds a nzb link to the remote client.
+    /// </summary>
+    /// <param name="link">The link to the publically accessible NZB file.</param>
+    /// <param name="post_processing">
+    /// Proccessing preference: 
+    /// -1 for default, being repair, unpack, and delete,
+    /// 0 for no post proccessing actions,
+    /// 1 for repair files,
+    /// 2 for repair and unpack files,
+    /// 3 for repair, unpack, and delete source files.
+    /// </param>
+    /// <param name="name">Optional name for the torrent.</param>
+    /// <param name="password">Optional password for the client to extract the files as.</param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// The response containing information about the added download.
+    /// </returns>
+    Task<Response<UsenetAddResult>> AddLinkAsync(string link, int post_processing = -1, string? name = null, string? password = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Modifies the state of a torrent (e.g., pause, resume, reannounce, delete).
+    /// </summary>
+    /// <param name="hash">The unique hash of the torrent.</param>
+    /// <param name="action">
+    /// The action to perform: pause, resume, or delete.
+    /// </param>
+    /// <param name="all">Deletes all usenet downloads on account. Defaults to false.</param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// The response after performing the action.
+    /// </returns>
+    Task<Response> ControlAsync(string hash, string action, bool all = false,  CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the availability of a torrent (whether it's cached and ready to download).
+    /// </summary>
+    /// <param name="hash">The unique hash identifier of the torrent.</param>
+    /// <param name="listFiles">Whether to include file list in the response.</param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// A response containing availability information for the download.
+    /// </returns>
+    Task<Response<List<AvailableUsenet?>>> GetAvailabilityAsync(string hash, bool listFiles = false, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Requests a download link for a specific usenet download wholly or file.
+    /// </summary>
+    /// <param name="usenet_id">The download id of the usenet item to download.</param>
+    /// <param name="file_id">The ID of the file within the usenet item (optional).</param>
+    /// <param name="zip">
+    /// Whether to download the entire item as a ZIP. Defaults to false. If true, file_id is ignored.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// A token to cancel the task if necessary.
+    /// </param>
+    /// <returns>
+    /// A response containing the download link.
+    /// </returns>
+    Task<Response<String>> RequestDownloadAsync(int usenet_id, int? file_id, bool zip = false, CancellationToken cancellationToken = default);
+}
+
+public class UsenetApi : IUsenetApi
+{
+    private readonly Requests _requests;
+    private readonly Store _store;
+    private readonly IQueuedApi _queued;
+
+    internal UsenetApi(HttpClient httpClient, Store store, IQueuedApi queued)
+    {
+        _requests = new Requests(httpClient, store);
+        _store = store;
+        _queued = queued;
+    }
+
+    /// <inheritdoc />
     public async Task<List<UsenetInfoResult>?> GetCurrentAsync(bool skipCache = false, CancellationToken cancellationToken = default)
     {
 
@@ -42,18 +184,7 @@ public class UsenetApi
         return JsonConvert.DeserializeObject<Response<List<UsenetInfoResult>>>(list)?.Data;
     }
 
-    /// <summary>
-    /// Fetches the list of active usenet downloads for the user.
-    /// </summary>
-    /// <param name="skipCache">
-    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// A list of usenet downloads if the request succeeds, otherwise null.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<List<UsenetInfoResult>?> GetQueuedAsync(bool skipCache = false, CancellationToken cancellationToken = default)
     {
 
@@ -90,19 +221,7 @@ public class UsenetApi
     }
 
 
-    /// <summary>
-    /// Retrieves detailed information about a specific usenet download by its hash.
-    /// </summary>
-    /// <param name="hash">The unique hash identifier of the torrent.</param>
-    /// <param name="skipCache">
-    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// Information about the download if found, otherwise null.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<UsenetInfoResult?> GetHashInfoAsync(string hash, bool skipCache = false, CancellationToken cancellationToken = default)
     {
         var currentDownloads = await GetCurrentAsync(skipCache, cancellationToken);
@@ -115,19 +234,7 @@ public class UsenetApi
         return currentDownloads.FirstOrDefault(item => item.Hash == hash);
     }
 
-    /// <summary>
-    /// Retrieves detailed information about a usenet download by its id.
-    /// </summary>
-    /// <param name="id">The unique hash identifier of the usenet download.</param>
-    /// <param name="skipCache">
-    /// Whether to bypass the cache and retrieve fresh data from the server. Defaults to false.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// Information about the download if found, otherwise null.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<UsenetInfoResult?> GetIdInfoAsync(int id, bool skipCache = false, CancellationToken cancellationToken = default)
     {
         var currentDownload = await _requests.GetRequestAsync<Response<UsenetInfoResult?>>($"usenet/mylist?bypass_cache={skipCache}", true, cancellationToken);
@@ -135,29 +242,7 @@ public class UsenetApi
         return currentDownload?.Data;
     }
 
-    /// <summary>
-    /// Adds a nzb file to the remote client.
-    /// </summary>
-    /// <param name="file">The nzb file as a byte array.</param>
-    /// <param name="post_processing">
-    /// Proccessing preference: 
-    /// -1 for default, being repair, unpack, and delete,
-    /// 0 for no post proccessing actions,
-    /// 1 for repair files,
-    /// 2 for repair and unpack files,
-    /// 3 for repair, unpack, and delete source files.
-    /// </param>
-    /// <param name="name">Optional name for the usenet download.</param>
-    /// <param name="password">Optional password for the client to extract the files as.</param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// The response containing information about the added download.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response<UsenetAddResult>> AddFileAsync(Byte[] file, int post_processing = -1, string? name = null, string? password = null, CancellationToken cancellationToken = default)
     {
         using var content = new MultipartFormDataContent();
@@ -183,26 +268,7 @@ public class UsenetApi
         return await _requests.PostRequestMultipartAsync<Response<UsenetAddResult>>("usenet/createusenetdownload", content, true, cancellationToken);
     }
 
-    /// <summary>
-    /// Adds a nzb link to the remote client.
-    /// </summary>
-    /// <param name="link">The link to the publically accessible NZB file.</param>
-    /// <param name="post_processing">
-    /// Proccessing preference: 
-    /// -1 for default, being repair, unpack, and delete,
-    /// 0 for no post proccessing actions,
-    /// 1 for repair files,
-    /// 2 for repair and unpack files,
-    /// 3 for repair, unpack, and delete source files.
-    /// </param>
-    /// <param name="name">Optional name for the torrent.</param>
-    /// <param name="password">Optional password for the client to extract the files as.</param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// The response containing information about the added download.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response<UsenetAddResult>> AddLinkAsync(string link, int post_processing = -1, string? name = null, string? password = null, CancellationToken cancellationToken = default)
     {
         var data = new List<KeyValuePair<string, string?>>
@@ -216,20 +282,7 @@ public class UsenetApi
         return await _requests.PostRequestAsync<Response<UsenetAddResult>>("usenet/createusenetdownload", data, true, cancellationToken);
     }
 
-    /// <summary>
-    /// Modifies the state of a torrent (e.g., pause, resume, reannounce, delete).
-    /// </summary>
-    /// <param name="hash">The unique hash of the torrent.</param>
-    /// <param name="action">
-    /// The action to perform: pause, resume, or delete.
-    /// </param>
-    /// <param name="all">Deletes all usenet downloads on account. Defaults to false.</param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// The response after performing the action.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response> ControlAsync(string hash, string action, bool all = false,  CancellationToken cancellationToken = default)
     {
         var info = await GetHashInfoAsync(hash, skipCache: true, cancellationToken);
@@ -245,36 +298,13 @@ public class UsenetApi
         return await _requests.PostRequestRawAsync<Response>("usenet/controlusenetdownload", jsonContent, true, cancellationToken);
     }
 
-    /// <summary>
-    /// Retrieves the availability of a torrent (whether it's cached and ready to download).
-    /// </summary>
-    /// <param name="hash">The unique hash identifier of the torrent.</param>
-    /// <param name="listFiles">Whether to include file list in the response.</param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// A response containing availability information for the download.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response<List<AvailableUsenet?>>> GetAvailabilityAsync(string hash, bool listFiles = false, CancellationToken cancellationToken = default)
     {
         return await _requests.GetRequestAsync<Response<List<AvailableUsenet?>>>($"usenet/checkcached?hash={hash}&format=list&list_files={listFiles}", true, cancellationToken);
     }
 
-    /// <summary>
-    /// Requests a download link for a specific usenet download wholly or file.
-    /// </summary>
-    /// <param name="usenet_id">The download id of the usenet item to download.</param>
-    /// <param name="file_id">The ID of the file within the usenet item (optional).</param>
-    /// <param name="zip">
-    /// Whether to download the entire item as a ZIP. Defaults to false. If true, file_id is ignored.
-    /// </param>
-    /// <param name="cancellationToken">
-    /// A token to cancel the task if necessary.
-    /// </param>
-    /// <returns>
-    /// A response containing the download link.
-    /// </returns>
+    /// <inheritdoc />
     public async Task<Response<String>> RequestDownloadAsync(int usenet_id, int? file_id, bool zip = false, CancellationToken cancellationToken = default)
     {
         var parameters = HttpUtility.ParseQueryString(string.Empty);

--- a/TorBoxNET/Apis/User.cs
+++ b/TorBoxNET/Apis/User.cs
@@ -2,15 +2,8 @@
 
 namespace TorBoxNET;
 
-public class UserApi
+public interface IUserApi
 {
-    private readonly Requests _requests;
-
-    internal UserApi(HttpClient httpClient, Store store)
-    {
-        _requests = new Requests(httpClient, store);
-    }
-
     /// <summary>
     ///     Returns information about logged in user.
     /// </summary>
@@ -22,6 +15,19 @@ public class UserApi
     /// <returns>
     ///     The currently logged in user.
     /// </returns>
+    Task<Response<User>> GetAsync(bool settings, CancellationToken cancellationToken = default);
+}
+
+public class UserApi : IUserApi
+{
+    private readonly Requests _requests;
+
+    internal UserApi(HttpClient httpClient, Store store)
+    {
+        _requests = new Requests(httpClient, store);
+    }
+
+    /// <inheritdoc />
     public async Task<Response<User>> GetAsync(bool settings, CancellationToken cancellationToken = default)
     {
         return await _requests.GetRequestAsync<Response<User>>($"user/me?settings={settings}", true, cancellationToken);

--- a/TorBoxNET/TorBoxNetClient.cs
+++ b/TorBoxNET/TorBoxNetClient.cs
@@ -1,17 +1,63 @@
 ﻿namespace TorBoxNET;
 
+public interface ITorBoxNetClient
+{
+    IQueuedApi Queued { get; }
+    ITorrentsApi Torrents { get; }
+    IUsenetApi Usenet { get; }
+    IUserApi User { get; }
+
+    /// <summary>
+    ///     Initialize the API to use ApiToken authentication. The token must be manually retrieved from
+    ///     https://real-debrid.com/apitoken and stored in your application.
+    /// </summary>
+    /// <param name="apiKey">
+    ///     The API for the user, retrieved from https://real-debrid.com/apitoken.
+    /// </param>
+    void UseApiAuthentication(String apiKey);
+
+    /// <summary>
+    ///     Initialize the API to use three legged OAuth2 authentication.
+    ///     This method should also be used for device authentication.
+    ///     To see the flow use https://api.real-debrid.com/#device_auth as a reference.
+    ///     To use call the following methods:
+    ///     - OAuthAuthorizationUrl
+    ///     - OAuthAuthorizationResponseAsync
+    ///     When receiving the authentication tokens, save the "AccessToken" and "RefreshToken" in your database for future for each user.
+    /// 
+    ///     To use device authentication use the following methods first:
+    ///     - GetDevicdeCode
+    ///     - DeviceAuthVerifyAsync. Poll this method every 5 seconds.
+    ///     - OAuthAuthorizationResponseAsync. Use this to trade the device code for an access token.
+    ///     When receiving the authentication tokens, save the "ClientId", "ClientSecret", "AccessToken" and "RefreshToken" in your database for future for each user.
+    /// </summary>
+    /// <param name="clientId">
+    ///     The client_id for your application or received client_id from token authentication.
+    /// </param>
+    /// <param name="clientSecret">
+    ///     The client_secret for your application or received client_id from token authentication.
+    /// </param>
+    /// <param name="accessToken">
+    ///     The access_token from previously authenticated user.
+    /// </param>
+    /// <param name="refreshToken">
+    ///     The refresh_token from previously authenticated user.
+    /// </param>
+    void UseOAuthAuthentication(String? clientId = null, String? clientSecret = null, String? accessToken = null, String? refreshToken = null);
+}
+
 /// <summary>
 ///     The RdNetClient consumed the Real-Debrid.com API.
 ///     Documentation about the API can be found here: https://api.real-debrid.com/
 /// </summary>
-public class TorBoxNetClient
+public class TorBoxNetClient : ITorBoxNetClient
 {
     private readonly Store _store = new();
 
-    public QueuedApi Queued { get; }
-    public TorrentsApi Torrents { get; }
-    public UsenetApi Usenet { get; }
-    public UserApi User { get; }
+    public IQueuedApi Queued { get; }
+    public ITorrentsApi Torrents { get; }
+    public IUsenetApi Usenet { get; }
+    public IUserApi User { get; }
         
     /// <summary>
     ///     Initialize the RdNet API.
@@ -41,13 +87,7 @@ public class TorBoxNetClient
         User = new UserApi(client, _store);
     }
 
-    /// <summary>
-    ///     Initialize the API to use ApiToken authentication. The token must be manually retrieved from
-    ///     https://real-debrid.com/apitoken and stored in your application.
-    /// </summary>
-    /// <param name="apiKey">
-    ///     The API for the user, retrieved from https://real-debrid.com/apitoken.
-    /// </param>
+    /// <inheritdoc />
     public void UseApiAuthentication(String apiKey)
     {
         if (String.IsNullOrWhiteSpace(apiKey))
@@ -60,33 +100,7 @@ public class TorBoxNetClient
         _store.ApiKey = apiKey;
     }
 
-    /// <summary>
-    ///     Initialize the API to use three legged OAuth2 authentication.
-    ///     This method should also be used for device authentication.
-    ///     To see the flow use https://api.real-debrid.com/#device_auth as a reference.
-    ///     To use call the following methods:
-    ///     - OAuthAuthorizationUrl
-    ///     - OAuthAuthorizationResponseAsync
-    ///     When receiving the authentication tokens, save the "AccessToken" and "RefreshToken" in your database for future for each user.
-    /// 
-    ///     To use device authentication use the following methods first:
-    ///     - GetDevicdeCode
-    ///     - DeviceAuthVerifyAsync. Poll this method every 5 seconds.
-    ///     - OAuthAuthorizationResponseAsync. Use this to trade the device code for an access token.
-    ///     When receiving the authentication tokens, save the "ClientId", "ClientSecret", "AccessToken" and "RefreshToken" in your database for future for each user.
-    /// </summary>
-    /// <param name="clientId">
-    ///     The client_id for your application or received client_id from token authentication.
-    /// </param>
-    /// <param name="clientSecret">
-    ///     The client_secret for your application or received client_id from token authentication.
-    /// </param>
-    /// <param name="accessToken">
-    ///     The access_token from previously authenticated user.
-    /// </param>
-    /// <param name="refreshToken">
-    ///     The refresh_token from previously authenticated user.
-    /// </param>
+    /// <inheritdoc />
     public void UseOAuthAuthentication(String? clientId = null, String? clientSecret = null, String? accessToken = null, String? refreshToken = null)
     {
         _store.AuthenticationType = AuthenticationType.OAuth2;


### PR DESCRIPTION
By exposing interfaces for `ITorBoxNetClient` and its apis, consumers of the library can mock a TorBoxNetClient

See also https://github.com/rogerfar/Alldebrid.NET/pull/9, https://github.com/rogerfar/rdt-client/pull/691.
