### PR TITLE
Fix: Corrected error code assignment in TorBoxException

### DIFF
--- a/TorBoxNET/Exceptions/TorBoxException.cs
+++ b/TorBoxNET/Exceptions/TorBoxException.cs
@@ -3,10 +3,10 @@
 public class TorBoxException : Exception
 {
     public TorBoxException(String? error, String? detail)
-        : base(GetMessage(error) ?? error)
+        : base(detail ?? error)
     {
         ErrorDetail = detail;
-        Error = GetMessage(error) ?? "NULL_DETAIL_ERROR";
+        Error = error ?? "NULL_DETAIL_ERROR";
     }
 
     public String Error { get; }


### PR DESCRIPTION
Exception messages were showing the same "detailed" message for both "Error" and "Detail" fields of the exception. Fixed that behaviour so that Error shows the code, Detail the user presentable message, following the recommendations from TorBox: https://documenter.getpostman.com/view/29572726/2s9YXo1zX4#062b717f-4866-4fc0-a3e6-6e4c2520eefa
