### PR TITLE
Add `as_queued` parameter to add Torrent/Usenet (default false)

### DIFF
--- a/TorBoxNET/Apis/Torrents.cs
+++ b/TorBoxNET/Apis/Torrents.cs
@@ -78,7 +78,7 @@ public interface ITorrentsApi
     /// <returns>
     /// Information about the torrent if found, otherwise null.
     /// </returns>
-    Task<TorrentInfoResult?> GetHashInfoAsync(string hash, bool skipCache = false, CancellationToken cancellationToken = default);
+    Task<TorrentInfoResult?> GetHashInfoAsync(string hash, bool skipCache = false, bool as_queued = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a torrent file to the torrent client.
@@ -95,7 +95,7 @@ public interface ITorrentsApi
     /// <returns>
     /// The response containing information about the added torrent.
     /// </returns>
-    Task<Response<TorrentAddResult>> AddFileAsync(Byte[] file, int seeding = 1, bool allowZip = false, string? name = null, CancellationToken cancellationToken = default);
+    Task<Response<TorrentAddResult>> AddFileAsync(Byte[] file, int seeding = 1, bool allowZip = false, string? name = null, bool as_queued = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a magnet link to the torrent client.
@@ -297,7 +297,7 @@ public class TorrentsApi : ITorrentsApi
     }
 
     /// <inheritdoc />
-    public async Task<Response<TorrentAddResult>> AddFileAsync(Byte[] file, int seeding = 1, bool allowZip = false, string? name = null, CancellationToken cancellationToken = default)
+    public async Task<Response<TorrentAddResult>> AddFileAsync(Byte[] file, int seeding = 1, bool allowZip = false, string? name = null, bool as_queued = false, CancellationToken cancellationToken = default)
     {
         using (var content = new MultipartFormDataContent())
         {
@@ -312,6 +312,7 @@ public class TorrentsApi : ITorrentsApi
             content.Add(fileContent);
             content.Add(new StringContent(seeding.ToString()), "seed");
             content.Add(new StringContent(allowZip.ToString()), "allow_zip");
+            content.Add(new StringContent(as_queued.ToString()), "as_queued");
 
             if (name != null)
             {
@@ -323,13 +324,14 @@ public class TorrentsApi : ITorrentsApi
     }
 
     /// <inheritdoc />
-    public async Task<Response<TorrentAddResult>> AddMagnetAsync(string magnet, int seeding = 1, bool allowZip = false, string? name = null, CancellationToken cancellationToken = default)
+    public async Task<Response<TorrentAddResult>> AddMagnetAsync(string magnet, int seeding = 1, bool allowZip = false, string? name = null, bool as_queued = false, CancellationToken cancellationToken = default)
     {
         var data = new List<KeyValuePair<string, string?>>
         {
             new KeyValuePair<string, string?>("magnet", magnet),
             new KeyValuePair<string, string?>("seed", seeding.ToString()),
             new KeyValuePair<string, string?>("allow_zip", allowZip.ToString()),
+            new KeyValuePair<string, string?>("as_queued", as_queued.ToString()),
             new KeyValuePair<string, string?>("name", name)
         };
 

--- a/TorBoxNET/Apis/Torrents.cs
+++ b/TorBoxNET/Apis/Torrents.cs
@@ -78,7 +78,7 @@ public interface ITorrentsApi
     /// <returns>
     /// Information about the torrent if found, otherwise null.
     /// </returns>
-    Task<TorrentInfoResult?> GetHashInfoAsync(string hash, bool skipCache = false, bool as_queued = false, CancellationToken cancellationToken = default);
+    Task<TorrentInfoResult?> GetHashInfoAsync(string hash, bool skipCache = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a torrent file to the torrent client.
@@ -112,7 +112,7 @@ public interface ITorrentsApi
     /// <returns>
     /// The response containing information about the added torrent.
     /// </returns>
-    Task<Response<TorrentAddResult>> AddMagnetAsync(string magnet, int seeding = 1, bool allowZip = false, string? name = null, CancellationToken cancellationToken = default);
+    Task<Response<TorrentAddResult>> AddMagnetAsync(string magnet, int seeding = 1, bool allowZip = false, string? name = null, bool as_queued = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Modifies the state of a torrent (e.g., pause, resume, reannounce, delete).

--- a/TorBoxNET/Apis/Usenet.cs
+++ b/TorBoxNET/Apis/Usenet.cs
@@ -87,7 +87,7 @@ public interface IUsenetApi
     /// <returns>
     /// The response containing information about the added download.
     /// </returns>
-    Task<Response<UsenetAddResult>> AddFileAsync(Byte[] file, int post_processing = -1, string? name = null, string? password = null, CancellationToken cancellationToken = default);
+    Task<Response<UsenetAddResult>> AddFileAsync(Byte[] file, int post_processing = -1, string? name = null, string? password = null, bool as_queued = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Adds a nzb link to the remote client.
@@ -109,7 +109,7 @@ public interface IUsenetApi
     /// <returns>
     /// The response containing information about the added download.
     /// </returns>
-    Task<Response<UsenetAddResult>> AddLinkAsync(string link, int post_processing = -1, string? name = null, string? password = null, CancellationToken cancellationToken = default);
+    Task<Response<UsenetAddResult>> AddLinkAsync(string link, int post_processing = -1, string? name = null, string? password = null, bool as_queued = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Modifies the state of a torrent (e.g., pause, resume, reannounce, delete).
@@ -243,7 +243,7 @@ public class UsenetApi : IUsenetApi
     }
 
     /// <inheritdoc />
-    public async Task<Response<UsenetAddResult>> AddFileAsync(Byte[] file, int post_processing = -1, string? name = null, string? password = null, CancellationToken cancellationToken = default)
+    public async Task<Response<UsenetAddResult>> AddFileAsync(Byte[] file, int post_processing = -1, string? name = null, string? password = null, bool as_queued = false, CancellationToken cancellationToken = default)
     {
         using var content = new MultipartFormDataContent();
         var fileContent = new ByteArrayContent(file);
@@ -256,6 +256,7 @@ public class UsenetApi : IUsenetApi
 
         content.Add(fileContent, "file");
         content.Add(new StringContent(post_processing.ToString()), "post_processing");
+        content.Add(new StringContent(as_queued.ToString()), "as_queued");
         if (name != null)
         {
             content.Add(new StringContent(name), "name");
@@ -269,12 +270,13 @@ public class UsenetApi : IUsenetApi
     }
 
     /// <inheritdoc />
-    public async Task<Response<UsenetAddResult>> AddLinkAsync(string link, int post_processing = -1, string? name = null, string? password = null, CancellationToken cancellationToken = default)
+    public async Task<Response<UsenetAddResult>> AddLinkAsync(string link, int post_processing = -1, string? name = null, string? password = null, bool as_queued = false, CancellationToken cancellationToken = default)
     {
         var data = new List<KeyValuePair<string, string?>>
         {
             new KeyValuePair<string, string?>("link", link),
             new KeyValuePair<string, string?>("post_processing", post_processing.ToString()),
+            new KeyValuePair<string, string?>("as_queued", as_queued.ToString()),
             //new KeyValuePair<string, string?>("name", name),
             new KeyValuePair<string, string?>("password", password),
         };


### PR DESCRIPTION
Also adding for Torrent API.

Parameter allow specifying that an add should be queued instead of started immediately. This allows placing addition adds if the users download slots are fully used up.

Defaults to false preserving the default behaviour of the API.

API Docs: https://documenter.getpostman.com/view/29572726/2s9YXo1zX4#daacc348-3e3c-476e-8362-f35124a8ca46